### PR TITLE
Make jb-rotary service more robust

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,12 @@ else
     git clone https://github.com/PiSupply/JustBoom.git
     mkdir /opt/justboom
     cp $JustBoomDir/jb-rotary.py /opt/justboom
-    cp $JustBoomDir/jb-rotary.service /etc/systemd/system
+    cp $JustBoomDir/jb-rotary.service /usr/lib/systemd/system
+    cp $JustBoomDir/jb-rotary.timer /usr/lib/systemd/system
 
-    systemctl enable /etc/systemd/system/jb-rotary.service
-    systemctl start jb-rotary.service
+    systemctl daemon-reload
+    systemctl disable jb-rotary.service
+    systemctl enable jb-rotary.timer
+    systemctl start jb-rotary.timer
 whiptail --title "Installation complete" --msgbox "The JustBoom Rotary Volume Control installation complete. Please reboot your Raspberry Pi now." 8 78
 fi

--- a/jb-rotary.py
+++ b/jb-rotary.py
@@ -71,6 +71,7 @@ class EasyMixer:
         self.clk = clk # First rotary pin
         self.dt = dt # Second rotary pin
         self.btn = btn # Button pin
+        self.rotary = None
 
         # Is the rotary encoder keyes like i.e. pull down or standard i.e. pull up
         if rot_type in ROTARY_TYPES:
@@ -82,21 +83,22 @@ class EasyMixer:
 
         # Finds the JustBoom card
         for i in range(len(alsaaudio.cards())):
+            print(alsaaudio.cards()[i])
             if (alsaaudio.cards()[i]=='sndrpiboomberry' or alsaaudio.cards()[i]=='sndrpijustboomd'):
                 cardId=i
-                if 'Digital' in alsaaudio.mixers():
+                if 'Digital' in alsaaudio.mixers(cardId):
                     self.mixer = alsaaudio.Mixer(control='Digital', cardindex=cardId)
                     self.hasMute = True
-                elif 'SoftMaster' in alsaaudio.mixers():
+                elif 'SoftMaster' in alsaaudio.mixers(cardId):
                     self.mixer = alsaaudio.Mixer(control='SoftMaster', cardindex=cardId)
                     self.hasMute = False
                 else:
                     print("There are no suitable mixers")
                     exit()
-            else:
-                print("There are no suitable cards")
-                exit()
-            self.rotary = Rotary(self.clk, self.dt, self.btn, self.rotarychange, self.buttonpressed, self.rot_type)
+                self.rotary = Rotary(self.clk, self.dt, self.btn, self.rotarychange, self.buttonpressed, self.rot_type)
+        if self.rotary == None:
+            print("There are no suitable cards")
+            exit()
 
     def getmute(self):
         self.isMute = self.mixer.getmute()[0]

--- a/jb-rotary.service
+++ b/jb-rotary.service
@@ -6,6 +6,3 @@ Requires=local-fs.target
 Type=simple
 ExecStart=/opt/justboom/jb-rotary.py
 WorkingDirectory=/opt/justboom/
-
-[Install]
-WantedBy=multi-user.target

--- a/jb-rotary.timer
+++ b/jb-rotary.timer
@@ -1,0 +1,8 @@
+[Unit]
+Desciption=Delay jb-rotary till ALSA available
+
+[Timer]
+OnStartupSec=20
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Modified jb-rotary.py to detect the justboom card even when the
on-board audio (ALSA) is active.

Not sure if the possible card names have to be updated/extended.

Had to delay the start of the service, since it started too early
before the alsa devices were available. Current delay is 20 sec. Hope
that is sufficient for all cases.

Please review and test before merging.