### PR TITLE
Fixed typo and link

### DIFF
--- a/LIRC/README.md
+++ b/LIRC/README.md
@@ -46,9 +46,9 @@ dtparam=gpio_in_pin=25
 in My OSMC -> Remotes
 Browse and choose the folder in which you have saved the following two files 
 
-justboom-ir-remote-lircd.conf
+`justboom-ir-remote-lircd.conf`
 
-justboom-ir-remote-lircd.png
+`justboom-ir-remote-lircd.png`
 
 reboot the OS
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Rotary SW         -> pin 10
 Rotary +          -> 3V3 (pin 1)
 Rotary GND        -> GND (pin 14)
 ```
-You can find the [assembly steps for the standard rotary encoder](https://www.justboom.co/tutorials/add-rotary-encoder-justboom-boards/) on our website. You can find the [standard rotary encoder](https://www.pi-supply.com/product/rotary-encoder-push-switch/)on our site.
+You can find the [assembly steps for the standard rotary encoder](https://www.justboom.co/tutorials/add-rotary-encoder-justboom-boards/) on our website. You can find the [standard rotary encoder](https://www.pi-supply.com/product/rotary-encoder-push-switch/) on our site.
 
 If you are planning on installing the rotary encoder on the [JustBoom DAC HAT check the FAQ](https://www.justboom.co/faqs/#FAQ-6) on the website for additional details.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Rotary GND        -> GND (pin 14)
 ```
 You can find the [assembly steps for the standard rotary encoder](https://www.justboom.co/tutorials/add-rotary-encoder-justboom-boards/) on our website. You can find the [standard rotary encoder](https://www.pi-supply.com/product/rotary-encoder-push-switch/) on our site.
 
-If you are planning on installing the rotary encoder on the [JustBoom DAC HAT check the FAQ](https://www.justboom.co/faqs/#FAQ-6) on the website for additional details.
+If you are planning on installing the rotary encoder on the [JustBoom DAC HAT, check the FAQ](https://www.justboom.co/faqs/#FAQ-7) on the website for additional details.
 
 ## LIRC lircd.conf
 This is the configuration file for the JustBoom IR Remote to be used in conjunction with LIRC.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ on the command line execute these two commands:
 sudo systemctl stop serial-getty@ttyS0.service
 sudo systemctl disable serial-getty@ttyS0.service
 ```
-and remove the following line from /boot/cmdline.txt
+and remove the following line from `/boot/cmdline.txt`
 ```
 console=serial0,115200
 ```
@@ -160,10 +160,10 @@ Back    0x224
 Vol-    0xEA
 Vol+    0xE9
 ```
-The mouse mode is activated by pressing the button in between Vol- and Vol+. The pointer is controlled by the built in gyroscope.
+The mouse mode is activated by pressing the button in between `Vol-` and `Vol+`. The pointer is controlled by the built in gyroscope.
 
 ## ALSA file for Surround Systems
-JustBoomDigi.conf enables passthrough DTS for surround systems. The file needs to be saved under /usr/share/alsa/cards
+`JustBoomDigi.conf` enables passthrough DTS for surround systems. The file needs to be saved under `/usr/share/alsa/cards`
 
 ## Chips, I2C and Pinout
 The pinout for the boards can be found on the [JustBoom website](https://www.justboom.co/technical-guides/boards-pinout/) or on [Pinout.xyz](https://pinout.xyz/boards#manufacturer=JustBoom)

--- a/REST API/README.md
+++ b/REST API/README.md
@@ -18,7 +18,7 @@ Available commands:
 ```
 justboom.local/api/v1/commands/?cmd=play&N=2
 ```
-Where N is optional and is the ordinal number of the track in the queue you wish to start to play from. The above call will play the third track in the queue.
+Where `N` is optional and is the ordinal number of the track in the queue you wish to start to play from. The above call will play the third track in the queue.
 
 **Toggle between play and pause**
 ```
@@ -44,7 +44,7 @@ justboom.local/api/v1/commands/?cmd=next
 ```
 justboom.local/api/v1/commands/?cmd=volume&volume=80
 ```
-Where volume= can be: 0-100, mute, unmute, plus, minus (plus and minus will increase/decrease as per parameter one click volume steps)
+Where `volume=` can be: 0-100, mute, unmute, plus, minus (plus and minus will increase/decrease as per parameter one click volume steps)
 
 ## Music Library
 Get the current state of the player
@@ -67,16 +67,16 @@ justboom.local/api/v1/listplaylists
 ```
 justboom.local/api/v1/commands/?cmd=playplaylist&name=Rock
 ```
-Where name is the name of the playlist to play
+Where `name` is the name of the playlist to play
 
 **Repeat a track**
 ```
 justboom.local/api/v1/commands/?cmd=repeat&key
 ```
-Where key is true or false
+Where `key` is true or false
 
 **Random** Makes the order in which tracks are played random
 ```
 justboom.local/api/v1/commands/?cmd=random&key
 ```
-Where key is true or false
+Where `key` is true or false


### PR DESCRIPTION
Noticed a typo and incorrect link as I was reading over the rotary encoder script info, so thought I'd fix it.  Then kind of went and added some backticks to make file paths, variables, etc. a little clearer to see for myself. :)